### PR TITLE
feat: version.go file

### DIFF
--- a/version.go
+++ b/version.go
@@ -37,7 +37,7 @@ func GetVersionAsJSON() (string, error) {
 	return string(v), nil
 }
 
-func GetVersionAsXML() (string, error) {
+func XMLVersion() (string, error) {
 	v, err := xml.MarshalIndent(version, "", " ")
 	if err != nil {
 		return "", err

--- a/version.go
+++ b/version.go
@@ -24,7 +24,7 @@ func Agent() string {
 	return fmt.Sprintf("timetrace/%s", GetVersionAsString())
 }
 
-func GetVersionAsString() string {
+func StringVersion() string {
 	return fmt.Sprintf("%d.%d.%d-%s", version.Major, version.Minor, version.Patch, version.Meta)
 }
 

--- a/version.go
+++ b/version.go
@@ -28,7 +28,7 @@ func GetVersionAsString() string {
 	return fmt.Sprintf("%d.%d.%d-%s", version.Major, version.Minor, version.Patch, version.Meta)
 }
 
-func GetVersionAsJSON() (string, error) {
+func JSONVersion() (string, error) {
 	v, err := json.Marshal(version)
 	if err != nil {
 		return "", err

--- a/version.go
+++ b/version.go
@@ -1,0 +1,49 @@
+package timetracedb
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+)
+
+type Version struct {
+	Meta  string `json:"meta" xml:"meta"`
+	Major uint8  `json:"major" xml:"major"`
+	Minor uint8  `json:"minor" xml:"minor"`
+	Patch uint8  `json:"patch" xml:"patch"`
+}
+
+var version = Version{
+	Meta:  "beta",
+	Major: 0,
+	Minor: 1,
+	Patch: 0,
+}
+
+func Agent() string {
+	return fmt.Sprintf("timetrace/%s", GetVersionAsString())
+}
+
+func GetVersionAsString() string {
+	return fmt.Sprintf("%d.%d.%d-%s", version.Major, version.Minor, version.Patch, version.Meta)
+}
+
+func GetVersionAsJson() (string, error) {
+	v, err := json.Marshal(version)
+
+	if err != nil {
+		return "", err
+	}
+
+	return string(v), nil
+}
+
+func GetVersionAsXML() (string, error) {
+	v, err := xml.MarshalIndent(version, "", " ")
+
+	if err != nil {
+		return "", err
+	}
+
+	return string(v), nil
+}

--- a/version.go
+++ b/version.go
@@ -8,9 +8,9 @@ import (
 
 type Version struct {
 	Meta  string `json:"meta"  xml:"meta"`
-	Major uint8  `json:"major"  xml:"major"`
-	Minor uint8  `json:"minor"  xml:"minor"`
-	Patch uint8  `json:"patch"  xml:"patch"`
+	Major uint8  `json:"major" xml:"major"`
+	Minor uint8  `json:"minor" xml:"minor"`
+	Patch uint8  `json:"patch" xml:"patch"`
 }
 
 var version = Version{
@@ -30,7 +30,6 @@ func GetVersionAsString() string {
 
 func GetVersionAsJSON() (string, error) {
 	v, err := json.Marshal(version)
-
 	if err != nil {
 		return "", err
 	}
@@ -40,7 +39,6 @@ func GetVersionAsJSON() (string, error) {
 
 func GetVersionAsXML() (string, error) {
 	v, err := xml.MarshalIndent(version, "", " ")
-
 	if err != nil {
 		return "", err
 	}

--- a/version.go
+++ b/version.go
@@ -7,10 +7,10 @@ import (
 )
 
 type Version struct {
-	Meta  string `json:"meta" xml:"meta"`
-	Major uint8  `json:"major" xml:"major"`
-	Minor uint8  `json:"minor" xml:"minor"`
-	Patch uint8  `json:"patch" xml:"patch"`
+	Meta  string `json:"meta"  xml:"meta"`
+	Major uint8  `json:"major"  xml:"major"`
+	Minor uint8  `json:"minor"  xml:"minor"`
+	Patch uint8  `json:"patch"  xml:"patch"`
 }
 
 var version = Version{
@@ -28,7 +28,7 @@ func GetVersionAsString() string {
 	return fmt.Sprintf("%d.%d.%d-%s", version.Major, version.Minor, version.Patch, version.Meta)
 }
 
-func GetVersionAsJson() (string, error) {
+func GetVersionAsJSON() (string, error) {
 	v, err := json.Marshal(version)
 
 	if err != nil {


### PR DESCRIPTION
**Create `version.go` File that returns the version of TimeTraceDB in a few types**

- Fixes #19 